### PR TITLE
3.1.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = InfixParser
 url = https://github.com/KJ002/Py-MathParser
-version = 3.1.0
+version = 3.1.2
 
 author = James Butcher
 author_email = jamesbutcher167@gmail.com


### PR DESCRIPTION
MathEvaluator::eval return a long double instead of a float allowing for larger numbers to be returned